### PR TITLE
Add `SparseMatrix_ELL` class

### DIFF
--- a/src/SparseMatrix_ELL.hpp
+++ b/src/SparseMatrix_ELL.hpp
@@ -1,0 +1,65 @@
+#ifndef __SPMV570_COO__
+#define __SPMV570_COO__
+
+#include "SparseMatrix.hpp"
+
+namespace SpMV
+{
+    template <class fp_type>
+    class SparseMatrix_ELL : public SparseMatrix<fp_type>
+    {
+
+        //using SparseMatrix<fp_type>::SparseMatrix;
+
+        private:
+            size_t* I = nullptr;
+            size_t* J = nullptr;
+            fp_type* val = nullptr;
+        
+        public:
+            SparseMatrix_ELL(const size_t nrows, const size_t ncols) : SparseMatrix<fp_type>::SparseMatrix(nrows,ncols)
+            {
+                cout << "Hello From SparseMartix_COO" << endl;
+            };
+            void assembleStorage();
+            /*Some return type*/ void getFormat(/*some args*/);
+
+    };
+
+    template <class fp_type>
+    void SparseMatrix_ELL<fp_type>::assembleStorage()
+    {
+        assert(this->_state == building);
+        cout << "Hello from SparseMatrix_ELL::assembleStorage!" << endl;
+
+        //Convert this buildCoeff dictionary to I, J, val
+        this->I = (size_t*)malloc(this->_nnz * sizeof(size_t));
+        this->J = (size_t*)malloc(this->_nnz * sizeof(size_t));
+        this->val = (fp_type*)malloc(this->_nnz * sizeof(fp_type));
+
+        size_t n=0;
+        for(auto coeff : this->_buildCoeff)
+        {
+            I[n]   = coeff.first.first;
+            J[n]   = coeff.first.second;
+            val[n] = coeff.second;
+            n += 1;
+        }
+
+        // Destroy _buildCoeff
+
+        this->_state = assembled;
+        assert(this->_state == assembled);
+    }
+
+    template <class fp_type>
+    void SparseMatrix_ELL<fp_type>::getFormat()
+    {
+        assert(this->_state == assembled);
+        cout << "Hello from SparseMatrix_ELL::getFormat!" << endl;
+        
+        //return new SparseMatrix(this->_ncols,this->_nrows);
+    }
+}
+
+#endif


### PR DESCRIPTION
# Purpose

This pull request adds a class that inherits from `SparseMatrix` and implements the ELLPACK (ELL) sparse matrix storage format

Closes #16 
Closes #12 
Closes #21 
Closes #33 

#25 should be merged before this pull request

# Definition of Done

### The following methods are implemented:
- [ ] Constructor
- [ ] Destructor @jasminylim 
- [ ] `assembleStorage`
- [ ] `matVec` @dorukaks 
- [ ] `unassemble` @awvio 
- [ ] `getFormat` @ShiboTan 

### The following methods are documented:
- [ ] Constructor
- [ ] Destructor @jasminylim 
- [ ] `assembleStorage`
- [ ] `matVec` @dorukaks 
- [ ] `unassemble` @awvio 
- [ ] `getFormat` @umichyujl 

### The code is formatted correctly:
- [ ] Private attribute names start with `_`
- [ ] Attributes are always accessed via `this->`
- [ ] Method names use `camelCase`

### The code is correct:
- [ ] All unit tests are passing
- [ ] The docs build correctly
