### PR TITLE
Add `SparseMatrix_COO` class

### DIFF
--- a/src/SparseMatrix_COO.hpp
+++ b/src/SparseMatrix_COO.hpp
@@ -60,6 +60,7 @@ namespace SpMV
         
         //return new SparseMatrix(this->_ncols,this->_nrows);
     }
+    
 }
 
 #endif


### PR DESCRIPTION
# Purpose

This draft pull request adds a class that inherits from `SparseMatrix` and implements the Coordinate (COO) sparse matrix storage format. It will be marked as ready for review once it meets the definition of done below.

Closes #6 
Closes #7  
Closes #9  
Closes #14 
Closes #32  

#25 should be merged before this pull request

# Definition of Done

### The following methods are implemented:
- [ ] Constructor
- [ ] Destructor @jbpark94  #14 
- [ ] `assembleStorage` @rachelwahlberg #6   
- [ ] `matVec` @dorukaks #9 
- [ ] `unassemble` @rachelwahlberg #7  
- [ ] `getFormat` @ShiboTan #32  

### The following methods are documented:
- [ ] Constructor
- [ ] Destructor @jbpark94  
- [ ] `assembleStorage` @rachelwahlberg  
- [ ] `matVec` @dorukaks 
- [ ] `unassemble` @rachelwahlberg 
- [ ] `getFormat` @ShiboTan 

### The code is formatted correctly:
- [ ] Private attribute names start with `_`
- [ ] Attributes are always accessed via `this->`
- [ ] Method names use `camelCase`

### The code is correct:
- [ ] All unit tests are passing
- [ ] The docs build correctly
