### PR TITLE
Implemented export method using buildCoeff

### DIFF
--- a/src/SparseMatrix.hpp
+++ b/src/SparseMatrix.hpp
@@ -112,6 +112,13 @@ namespace SpMV {
        * @param y Vector y
        */
       virtual void computeMatVecProduct(const fp_type x[], fp_type y[]) = 0;
+
+      /**
+       * @brief Write the matrix to disk in MatrixMarket file format
+       *
+       * @param fileName Name of the file to write
+       */
+      void exportMatrix(char *fileName);
   };
 
   template <class fp_type>
@@ -145,6 +152,64 @@ namespace SpMV {
     assert(this->_state == assembled);
 
     // return new SparseMatrix(this->_ncols,this->_nrows);
+  }
+
+  template <class fp_type>
+  void SparseMatrix<fp_type>::exportMatrix(char *fileName) {
+    // Exit with warning if matrix is not assembled
+    if (this->_state != assembled) {
+      cout << "State error: This matrix is not assembled" << endl;
+      return;
+    }
+    outMat = getFormat(this, "COO");
+
+    // Open file
+    ofstream outfile;
+    outfile.open(fileName);
+
+    // Write preamble
+  private
+    char preamble = " %%MatrixMarket matrix coordinate real general"
+                    " %================================================================================="
+                    " %"
+                    " % This ASCII file represents a sparse MxN matrix with L "
+                    " % nonzeros in the following Matrix Market format:"
+                    " %"
+                    " % +----------------------------------------------+"
+                    " % |%%MatrixMarket matrix coordinate real general | <--- header line"
+                    " % |%                                             | <--+"
+                    " % |% comments                                    |    |-- 0 or more comment lines"
+                    " % |%                                             | <--+         "
+                    " % |    M  N  L                                   | <--- rows, columns, entries"
+                    " % |    I1  J1  A(I1, J1)                         | <--+"
+                    " % |    I2  J2  A(I2, J2)                         |    |"
+                    " % |    I3  J3  A(I3, J3)                         |    |-- L lines"
+                    " % |        . . .                                 |    |"
+                    " % |    IL JL  A(IL, JL)                          | <--+"
+                    " % +----------------------------------------------+   "
+                    " %"
+                    " % Indices are 1-based, i.e. A(1,1) is the first element."
+                    " %"
+                    " %=================================================================================";
+    outfile << m.write << endl;
+
+    // Write header line with matrix meta-data
+    outfile << outMat._nrows;
+    outfile << outMat._ncols;
+    outfile << outMat._nnz << endl;
+
+    // Write data of each nonzero matrix element
+      for{
+        int n = 0;
+        n < nnz;
+        i++
+      }
+      {
+        outfile << outMat.J[n];
+        outfile << outMat.I[n];
+        outfile << outMat.val[n] << endl;
+      }
+      outfile.close();
   }
 
 } // namespace SpMV


### PR DESCRIPTION
Added an export method for the base SparseMatrix class to write a file to disk in Matrix Market format. 

The method does not assume that the SparseMatrix it is being called on is in COO format already. Please review to verify if I am using the _buildCoeffs object correctly.
